### PR TITLE
Allow identifiers in macro

### DIFF
--- a/examples/hyperprimes.rs
+++ b/examples/hyperprimes.rs
@@ -1,0 +1,11 @@
+use algexenotation::*;
+
+use std::io::Write;
+
+fn main() {
+    for i in 0..10 {
+        print!("{}, ", ax!(i).original());
+        std::io::stdout().flush().unwrap();
+    }
+    println!("");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,6 +200,7 @@ fn hyperprime(n: u64) -> u64 {
 macro_rules! ax {
     ( $x:literal % ) => {Algexeno::Orig($x)};
     ( $x:literal ) => {Algexeno::Const($x)};
+    ( $x:ident ) => {Algexeno::Const($x)};
     ( ( $x:tt + $($y:tt)+ ) ) => {Algexeno::Bin(Op::Add, Box::new((ax!($x), ax!($($y)+))))};
     ( $x:tt + $($y:tt)+ ) => {Algexeno::Bin(Op::Add, Box::new((ax!($x), ax!($($y)+))))};
     ( ( $($x:tt)+ ) * $($y:tt)+ ) => {Algexeno::Bin(Op::Mul, Box::new((ax!($($x)+), ax!($($y)+))))};


### PR DESCRIPTION
- Added "hyperprimes" example